### PR TITLE
Implement Blog Comment using DISQUS

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,0 +1,18 @@
+{% if page.comments %}
+  <div id="disqus_thread"></div>
+  <script>
+  /**
+  *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+  *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables */
+    var disqus_config = function () {
+      this.page.url = "{{ site.url }}{{ page.url }}";
+    };
+    (function() { // DON'T EDIT BELOW THIS LINE
+      var d = document, s = d.createElement('script');
+      s.src = 'https://soundlly-github-io.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,5 +57,8 @@
         },
       });
     </script>
+
+    <!-- Disqus -->
+    <script id="dsq-count-scr" src="//soundlly-github-io.disqus.com/count.js" async></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -57,3 +57,5 @@ layout: default
     {% endfor %}
   </ul>
 </div>
+
+{% include disqus.html %}

--- a/_posts/2013-12-31-whats-jekyll.md
+++ b/_posts/2013-12-31-whats-jekyll.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: What's Jekyll?
+comments: true
 ---
 
 [Jekyll](http://jekyllrb.com) is a static site generator, an open-source tool for creating simple yet powerful websites of all shapes and sizes. From [the project's readme](https://github.com/mojombo/jekyll/blob/master/README.markdown):

--- a/_posts/2014-01-01-example-content.md
+++ b/_posts/2014-01-01-example-content.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Example content
+comments: true
 ---
 
 

--- a/_posts/2014-01-02-introducing-lanyon.md
+++ b/_posts/2014-01-02-introducing-lanyon.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Introducing Lanyon
+comments: true
 ---
 
 Lanyon is an unassuming [Jekyll](http://jekyllrb.com) theme that places content first by tucking away navigation in a hidden drawer. It's based on [Poole](http://getpoole.com), the Jekyll butler.

--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -314,6 +314,7 @@ tbody tr:nth-child(odd) th {
 }
 .masthead-title a {
   color: #E43D32;
+  font-weight: bold;
 }
 .masthead-title small {
   font-size: 75%;


### PR DESCRIPTION
### DISQUS

- Account : `dev@soundl.ly` in free-tier pricing
- DISQUS is rendered only if `comments: true` is stated in each post
- Adding`{% include disqus.html %}` is required for rendering DISQUS

### Misc

- Make company title `bold`
- CRLF => LF for files in `_posts/`

### References

- https://github.com/gnujoow/gnujoow.github.io
- http://sgeos.github.io/jekyll/disqus/2016/02/14/adding-disqus-to-a-jekyll-blog.html
- https://soundlly-github-io.disqus.com/admin/install/platforms/jekyll/
- https://soundlly-github-io.disqus.com/admin/install/platforms/universalcode/